### PR TITLE
 Update to league/commonmark 0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 parsing engine, which itself is based on the CommonMark spec.
 
 ## Current Custom Parsers and Renderers
-* **Strikethrough:** Parser and Renderer. Allows users to use `~~` in order to indicate text that should be rendered within `<del>` tags.
+* **Strikethrough:** Parser and Renderer. Allows users to use `~~` in order to indicate text that should be rendered within `<del>` tags.  To use it, add it to your environment object with `$env->addExtension(new \CommonmarkExt\Strikethrough\StrikethroughExtension())`.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Extended parsers and renderers for The PHP League CommonMark parser",
     "keywords": ["markdown", "strikethrough", "strikeout", "commonmark"],
     "require": {
-        "league/commonmark": "^0.10.0"
+        "league/commonmark": "^0.17"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "5"
     },
     "license": "MIT",
     "authors": [

--- a/src/Strikethrough/StrikethroughExtension.php
+++ b/src/Strikethrough/StrikethroughExtension.php
@@ -1,0 +1,16 @@
+<?php
+namespace CommonMarkExt\Strikethrough;
+
+use League\CommonMark\Extension\Extension;
+use League\CommonMark\Inline\Parser\InlineParserInterface;
+use League\CommonMark\Inline\Processor\InlineProcessorInterface;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+
+class StrikethroughExtension extends Extension
+{
+    public function getName(){ return 'Strikethrough'; }
+    public function getInlineParsers(){ return [ new StrikethroughParser() ]; }
+    public function getInlineProcessors(){ return []; }
+    public function getInlineRenderers(){ return [ Strikethrough::class => new StrikethroughRenderer() ]; }
+}
+

--- a/src/Strikethrough/StrikethroughParser.php
+++ b/src/Strikethrough/StrikethroughParser.php
@@ -22,7 +22,7 @@ class StrikethroughParser extends AbstractInlineParser
      *
      * @return bool
      */
-    public function parse(ContextInterface $context, InlineParserContext $inline_context)
+    public function parse(InlineParserContext $inline_context)
     {
         $cursor = $inline_context->getCursor();
         $character = $cursor->getCharacter();
@@ -37,19 +37,15 @@ class StrikethroughParser extends AbstractInlineParser
         $previous_state = $cursor->saveState();
         while ($matching_tildes = $cursor->match('/~~+/m')) {
             if ($matching_tildes === $tildes) {
-                $text = mb_substr($cursor->getLine(), $previous_state->getCurrentPosition(),
-                    $cursor->getPosition() - $previous_state->getCurrentPosition() - strlen($tildes), 'utf-8');
+                $text = mb_substr( $cursor->getPreviousText(), 0, -mb_strlen($tildes) );
                 $text = preg_replace('/[ \n]+/', ' ', $text);
-                $inline_context->getInlines()
-                    ->add(new Strikethrough(trim($text)));
+                $inline_context->getContainer()->appendChild(new Strikethrough(trim($text)));
                 return true;
             }
         }
         // If we got here, we didn't match a closing tilde pair sequence
         $cursor->restoreState($previous_state);
-        $inline_context->getInlines()
-            ->add(new Text($tildes));
-
+        $inline_context->getContainer()->appendChild(new Text($tildes));
         return true;
     }
 }

--- a/src/Strikethrough/StrikethroughRenderer.php
+++ b/src/Strikethrough/StrikethroughRenderer.php
@@ -5,6 +5,7 @@ use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use League\CommonMark\Util\Xml;
 
 class StrikethroughRenderer implements InlineRendererInterface
 {
@@ -24,6 +25,6 @@ class StrikethroughRenderer implements InlineRendererInterface
             $attrs[$key] = $htmlRenderer->escape($value, true);
         }
 
-        return new HtmlElement('del', $attrs, $htmlRenderer->escape($inline->getContent()));
+        return new HtmlElement('del', $attrs, Xml::escape($inline->getContent()));
     }
 }

--- a/src/Strikethrough/StrikethroughRenderer.php
+++ b/src/Strikethrough/StrikethroughRenderer.php
@@ -22,7 +22,7 @@ class StrikethroughRenderer implements InlineRendererInterface
         }
         $attrs = [];
         foreach ($inline->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         return new HtmlElement('del', $attrs, Xml::escape($inline->getContent()));

--- a/tests/StrikethroughTests/StrikethroughParserTest.php
+++ b/tests/StrikethroughTests/StrikethroughParserTest.php
@@ -17,7 +17,7 @@ class StrikethroughParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParse($string, $expected)
     {
-        $nodeStub = $this->getMock('League\CommonMark\Block\Element\AbstractBlock');
+        $nodeStub = $this->getMock(\League\CommonMark\Block\Element\AbstractBlock::class);
         $nodeStub->expects($this->any())->method('getStringContent')->willReturn($string);
         $nodeStub
             ->expects($this->once())

--- a/tests/StrikethroughTests/StrikethroughParserTest.php
+++ b/tests/StrikethroughTests/StrikethroughParserTest.php
@@ -5,6 +5,7 @@ use CommonMarkExt\Strikethrough\Strikethrough;
 use CommonMarkExt\Strikethrough\StrikethroughParser;
 use League\CommonMark\Cursor;
 use League\CommonMark\InlineParserContext;
+use League\CommonMark\Reference\ReferenceMap;
 
 class StrikethroughParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -16,20 +17,22 @@ class StrikethroughParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParse($string, $expected)
     {
-        $cursor = new Cursor($string);
+        $nodeStub = $this->getMock('League\CommonMark\Block\Element\AbstractBlock');
+        $nodeStub->expects($this->any())->method('getStringContent')->willReturn($string);
+        $nodeStub
+            ->expects($this->once())
+            ->method('appendChild')
+            ->with($this->callback(function (Strikethrough $s) use ($expected) {
+                return $s instanceof Strikethrough && $expected === $s->getContent();
+            }));
+        $inline_context = new InlineParserContext($nodeStub, new ReferenceMap());
+
         // Move to just before the first tilde pair
         $first_tilde_pos = mb_strpos($string, '~~', null, 'utf-8');
-        $cursor->advanceBy($first_tilde_pos);
-        $inline_context = new InlineParserContext($cursor);
-        $context_stub = $this->getMock('League\CommonMark\ContextInterface');
+        $inline_context->getCursor()->advanceBy($first_tilde_pos);
+
         $parser = new StrikethroughParser();
-        $parser->parse($context_stub, $inline_context);
-        $inlines = $inline_context->getInlines();
-        $this->assertCount(1, $inlines);
-        $this->assertTrue($inlines->first() instanceof Strikethrough);
-        /** @var Strikethrough $text */
-        $text = $inlines->first();
-        $this->assertEquals($expected, $text->getContent());
+        $parser->parse($inline_context);
     }
 
     /**

--- a/tests/StrikethroughTests/StrikethroughRendererTest.php
+++ b/tests/StrikethroughTests/StrikethroughRendererTest.php
@@ -22,13 +22,13 @@ class StrikethroughRendererTest extends \PHPUnit_Framework_TestCase
     public function testRender()
     {
         $inline = new Strikethrough('reviewed text');
-        $inline->data['attributes'] = ['id' => 'id'];
+        $inline->data['attributes'] = ['id' => 'some"&amp;id'];
         $fake_renderer = new FakeHtmlRenderer();
         $result = $this->renderer->render($inline, $fake_renderer);
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('del', $result->getTagName());
         $this->assertContains('reviewed text', $result->getContents(true));
-        $this->assertEquals(['id' => '::escape::id'], $result->getAllAttributes());
+        $this->assertEquals(['id' => 'some&quot;&amp;id'], $result->getAllAttributes());
     }
 
     /**


### PR DESCRIPTION
Per discussion in #1, this PR updates the extension to be compatible with the latest league/commonmark version.  It also adds a `StrikethroughExtension` class to make using it a one-liner.
