### PR TITLE
Use the new "commonmark-extension" package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "uafrica/commonmark-ext",
+    "type": "commonmark-extension",
     "description": "Extended parsers and renderers for The PHP League CommonMark parser",
     "keywords": ["markdown", "strikethrough", "strikeout", "commonmark"],
     "require": {


### PR DESCRIPTION
This makes it easier for people to find extensions on Packagist: https://packagist.org/packages/league/commonmark-ext-autolink?type=commonmark-extension